### PR TITLE
Removing notion of context from peerstore

### DIFF
--- a/peer/addrbook_interface.py
+++ b/peer/addrbook_interface.py
@@ -2,8 +2,8 @@ from abc import ABC, abstractmethod
 
 class IAddrBook(ABC):
 
-    def __init__(self, context):
-        self.context = context
+    def __init__(self):
+        pass
 
     @abstractmethod
     def add_addr(self, peer_id, addr, ttl):

--- a/peer/peermetadata_interface.py
+++ b/peer/peermetadata_interface.py
@@ -2,8 +2,8 @@ from abc import ABC, abstractmethod
 
 class IPeerMetadata(ABC):
 
-    def __init__(self, context):
-        self.context = context
+    def __init__(self):
+        pass
 
     @abstractmethod
     def get(self, peer_id, key):

--- a/peer/peerstore.py
+++ b/peer/peerstore.py
@@ -3,8 +3,8 @@ from .peerdata import PeerData
 
 class PeerStore(IPeerStore):
 
-    def __init__(self, context):
-        IPeerStore.__init__(self, context)
+    def __init__(self):
+        IPeerStore.__init__(self)
         self.peer_map = {}
 
     def __create_or_get_peer(self, peer_id):

--- a/peer/peerstore_interface.py
+++ b/peer/peerstore_interface.py
@@ -4,9 +4,9 @@ from .peermetadata_interface import IPeerMetadata
 
 class IPeerStore(ABC, IAddrBook, IPeerMetadata):
 
-    def __init__(self, context):
-        IPeerMetadata.__init__(self, context)
-        IAddrBook.__init__(self, context)
+    def __init__(self):
+        IPeerMetadata.__init__(self)
+        IAddrBook.__init__(self)
 
     @abstractmethod
     def peer_info(self, peer_id):


### PR DESCRIPTION
"Context" seems to be a Go-specific feature and we shouldn't need it in Python.