### PR TITLE
Dialer should not read until user says so.

### DIFF
--- a/muxer/mplex/muxed_connection.py
+++ b/muxer/mplex/muxed_connection.py
@@ -20,7 +20,10 @@ class MuxedConn(IMuxedConn):
         self.streams = {}
         self.stream_queue = asyncio.Queue()
 
-        asyncio.ensure_future(self.handle_incoming())
+        # The initiator need not read upon construction time.
+        # It should read when the user decides that it wants to read from the constructed stream.
+        if not initiator:
+            asyncio.ensure_future(self.handle_incoming())
 
     def close(self):
         """


### PR DESCRIPTION
Currently we haven't used our `initiator` variable indicating whether the creator of a muxed_connection is the dialer or not. The dialer should not read upon construction time - it need only read when the user (who is initiating a connection to another peer) decides to read a response from its stream. Otherwise, the double-read will error out.

This bug is exposed by the chat example given in #16.