### PR TITLE
Improved stream IDs

### DIFF
--- a/network/swarm.py
+++ b/network/swarm.py
@@ -59,9 +59,7 @@ class Swarm(INetwork):
 
         # Use muxed conn to open stream, which returns
         # a muxed stream
-        # TODO: use better stream IDs
-        stream_id = (uuid.uuid4().int & (1<<64)-1) >> 3
-        muxed_stream = muxed_conn.open_stream(protocol_id, stream_id, peer_id, multiaddr)
+        muxed_stream = await muxed_conn.open_stream(protocol_id, peer_id, multiaddr)
 
         # Create a net stream
         net_stream = NetStream(muxed_stream)

--- a/stream_muxer/mplex/mplex_stream.py
+++ b/stream_muxer/mplex/mplex_stream.py
@@ -68,7 +68,7 @@ class MplexStream(IMuxedStream):
 
         if remote_lock:
             async with self.mplex_conn.conn_lock:
-                self.mplex_conn.streams.pop(self.stream_id)
+                self.mplex_conn.buffers.pop(self.stream_id)
 
         return True
 
@@ -91,7 +91,7 @@ class MplexStream(IMuxedStream):
             self.remote_closed = True
 
         async with self.mplex_conn.conn_lock:
-            self.mplex_conn.streams.pop(self.stream_id, None)
+            self.mplex_conn.buffers.pop(self.stream_id, None)
 
         return True
 

--- a/stream_muxer/muxed_connection_interface.py
+++ b/stream_muxer/muxed_connection_interface.py
@@ -23,7 +23,7 @@ class IMuxedConn(ABC):
         pass
 
     @abstractmethod
-    def open_stream(self, protocol_id, stream_id, peer_id, multi_addr):
+    def open_stream(self, protocol_id, peer_id, multi_addr):
         """
         creates a new muxed_stream
         :param protocol_id: protocol_id of stream


### PR DESCRIPTION
As per #53.

For the necessary context, see:
https://github.com/libp2p/specs/tree/master/mplex
https://github.com/libp2p/go-mplex/blob/master/multiplex.go#L164
https://github.com/libp2p/js-libp2p-mplex/blob/master/src/internals/index.js#L87

This PR:

- [ ] Moves stream ID construction to the `mplex` module.
- [ ] Simplifies stream IDs to be monotonically increasing counters (inspired by Go/JS impls). As per the `mplex` spec, we only require that stream IDs not be reused.
- [ ] Removes the notion of `self.streams` (a mapping from stream ID -> stream) in `mplex` in favor of just having `self.buffers` (a mapping from stream ID -> buffer for that stream). Having both is redundant; a muxed stream already passes down its stream ID to `mplex` when it wants to read/write, so this is sufficient.

CC @alexh: looking at the `go-mplex` implementation makes it clear that we'll want synchronization around any changes (including the check-then-set changes) made to `self.buffers`, but I left this out to wait for the `handle_incoming()` refactor.