### PR TITLE
Requiring Python >= 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ py-libp2p is an experimental and work-in-progress repo under heavy development. 
 
 ## Development
 
-py-libp2p requires Python 3.6 and the best way to guarantee a clean Python 3.6 environment is with [`virtualenv`](https://virtualenv.pypa.io/en/stable/)
+py-libp2p requires Python 3 (>= 3.7) and the best way to guarantee a clean Python 3 environment is with [`virtualenv`](https://virtualenv.pypa.io/en/stable/)
 
 ```sh
-virtualenv -p python3.6 venv
+virtualenv -p python3 venv
 . venv/bin/activate
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
As per [this post](https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-asyncio), 3.7 brought big improvements to `asyncio`.