### PR TITLE
don't manually assign port during test

### DIFF
--- a/tests/libp2p/test_libp2p.py
+++ b/tests/libp2p/test_libp2p.py
@@ -7,8 +7,8 @@ from peer.peerinfo import info_from_p2p_addr
 
 @pytest.mark.asyncio
 async def test_simple_messages():
-    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/8001"])
-    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/8000"])
+    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
+    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
 
     async def stream_handler(stream):
         while True:
@@ -41,8 +41,8 @@ async def test_simple_messages():
 
 @pytest.mark.asyncio
 async def test_double_response():
-    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/8002"])
-    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/8003"])
+    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
+    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
 
     async def stream_handler(stream):
         while True:
@@ -80,12 +80,13 @@ async def test_double_response():
     # Success, terminate pending tasks.
     return
 
+
 @pytest.mark.asyncio
 async def test_multiple_streams():
     # Node A should be able to open a stream with node B and then vice versa.
     # Stream IDs should be generated uniquely so that the stream state is not overwritten
-    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/8004"])
-    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/8005"])
+    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
+    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
 
     async def stream_handler_a(stream):
         while True:
@@ -128,10 +129,11 @@ async def test_multiple_streams():
     # Success, terminate pending tasks.
     return
 
+
 @pytest.mark.asyncio
 async def test_host_connect():
-    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/8001/"])
-    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/8000/"])
+    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
+    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
 
     assert not node_a.get_peerstore().peers()
 

--- a/tests/protocol_muxer/test_protocol_muxer.py
+++ b/tests/protocol_muxer/test_protocol_muxer.py
@@ -11,14 +11,14 @@ from protocol_muxer.multiselect_client import MultiselectClientError
 # TODO: modify tests so that those async issues don't occur
 # when using the same ports across tests
 
-async def perform_simple_test(expected_selected_protocol, \
-    protocols_for_client, protocols_with_handlers, \
-    node_a_port, node_b_port):
-    transport_opt_a = ["/ip4/127.0.0.1/tcp/" + str(node_a_port)]
-    transport_opt_b = ["/ip4/127.0.0.1/tcp/" + str(node_b_port)]
-    node_a = await new_node(\
+
+async def perform_simple_test(expected_selected_protocol,
+                              protocols_for_client, protocols_with_handlers):
+    transport_opt_a = ["/ip4/127.0.0.1/tcp/0"]
+    transport_opt_b = ["/ip4/127.0.0.1/tcp/0"]
+    node_a = await new_node(
         transport_opt=transport_opt_a)
-    node_b = await new_node(\
+    node_b = await new_node(
         transport_opt=transport_opt_b)
 
     async def stream_handler(stream):
@@ -51,38 +51,43 @@ async def perform_simple_test(expected_selected_protocol, \
     # Success, terminate pending tasks.
     return
 
+
 @pytest.mark.asyncio
 async def test_single_protocol_succeeds():
     expected_selected_protocol = "/echo/1.0.0"
-    await perform_simple_test(expected_selected_protocol, \
-        ["/echo/1.0.0"], ["/echo/1.0.0"], 8050, 8051)
+    await perform_simple_test(expected_selected_protocol,
+                              ["/echo/1.0.0"], ["/echo/1.0.0"])
+
 
 @pytest.mark.asyncio
 async def test_single_protocol_fails():
     with pytest.raises(MultiselectClientError):
-        await perform_simple_test("", ["/echo/1.0.0"], \
-            ["/potato/1.0.0"], 8052, 8053)
+        await perform_simple_test("", ["/echo/1.0.0"],
+                                  ["/potato/1.0.0"])
+
 
 @pytest.mark.asyncio
 async def test_multiple_protocol_first_is_valid_succeeds():
     expected_selected_protocol = "/echo/1.0.0"
     protocols_for_client = ["/echo/1.0.0", "/potato/1.0.0"]
     protocols_for_listener = ["/foo/1.0.0", "/echo/1.0.0"]
-    await perform_simple_test(expected_selected_protocol, protocols_for_client, \
-        protocols_for_listener, 8054, 8055)
+    await perform_simple_test(expected_selected_protocol, protocols_for_client,
+                              protocols_for_listener)
+
 
 @pytest.mark.asyncio
 async def test_multiple_protocol_second_is_valid_succeeds():
     expected_selected_protocol = "/foo/1.0.0"
     protocols_for_client = ["/rock/1.0.0", "/foo/1.0.0"]
     protocols_for_listener = ["/foo/1.0.0", "/echo/1.0.0"]
-    await perform_simple_test(expected_selected_protocol, protocols_for_client, \
-        protocols_for_listener, 8056, 8057)
+    await perform_simple_test(expected_selected_protocol, protocols_for_client,
+                              protocols_for_listener)
+
 
 @pytest.mark.asyncio
 async def test_multiple_protocol_fails():
     protocols_for_client = ["/rock/1.0.0", "/foo/1.0.0", "/bar/1.0.0"]
     protocols_for_listener = ["/aspyn/1.0.0", "/rob/1.0.0", "/zx/1.0.0", "/alex/1.0.0"]
     with pytest.raises(MultiselectClientError):
-        await perform_simple_test("", protocols_for_client, \
-            protocols_for_listener, 8058, 8059)
+        await perform_simple_test("", protocols_for_client,
+                                  protocols_for_listener)

--- a/tests/transport/test_tcp.py
+++ b/tests/transport/test_tcp.py
@@ -1,0 +1,20 @@
+import asyncio
+
+import pytest
+
+from transport.tcp.tcp import _multiaddr_from_socket
+
+
+@pytest.mark.asyncio
+async def test_multiaddr_from_socket():
+    def handler(r, w):
+        pass
+
+    server = await asyncio.start_server(handler, '127.0.0.1', 8000)
+    assert str(_multiaddr_from_socket(server.sockets[0])) == '/ip4/127.0.0.1/tcp/8000'
+
+    server = await asyncio.start_server(handler, '127.0.0.1', 0)
+    addr = _multiaddr_from_socket(server.sockets[0])
+    assert addr.value_for_protocol('ip4') == '127.0.0.1'
+    port = addr.value_for_protocol('tcp')
+    assert int(port) > 0


### PR DESCRIPTION
Following my idea in https://github.com/zixuanzh/py-libp2p/issues/89#issuecomment-442881962, instead of saving the multiaddr received in the listen method of the tcp transport class, read what the service is actually listening on this allow to use 0 as port and let the OS choose a free port for us.

2 remark on this though:
- is it ok to make the tcp transport depend on the multiaddr lib ?
- the function I added to read the actual port listening has `ip4` hard-coded in it. It seems the rest of the file too, but maybe we want to already plan to support ip6 or other protocols

fixes #89