### PR TITLE
Updating to proper multiaddr dependency

### DIFF
--- a/host/basic_host.py
+++ b/host/basic_host.py
@@ -42,7 +42,7 @@ class BasicHost(IHost):
         """
         :return: all the multiaddr addresses this host is listening too
         """
-        p2p_part = multiaddr.Multiaddr('/ipfs/{}'.format(self.get_id().pretty()))
+        p2p_part = multiaddr.Multiaddr('/p2p/{}'.format(self.get_id().pretty()))
 
         addrs = []
         for transport in self.network.listeners.values():

--- a/peer/peerinfo.py
+++ b/peer/peerinfo.py
@@ -19,12 +19,12 @@ def info_from_p2p_addr(addr):
     if not parts:
         raise InvalidAddrError()
 
-    p2ppart = parts[-1]
-    if p2ppart.protocols()[0].code != multiaddr.protocols.P_P2P:
+    p2p_part = parts[-1]
+    if p2p_part.protocols()[0].code != multiaddr.protocols.P_P2P:
         raise InvalidAddrError()
 
     # make sure the /p2p value parses as a peer.ID
-    peer_id_str = p2ppart.value_for_protocol(multiaddr.protocols.P_P2P)
+    peer_id_str = p2p_part.value_for_protocol(multiaddr.protocols.P_P2P)
     peer_id = id_b58_decode(peer_id_str)
 
     # we might have received just an / p2p part, which means there's no addr.

--- a/peer/peerinfo.py
+++ b/peer/peerinfo.py
@@ -19,15 +19,15 @@ def info_from_p2p_addr(addr):
     if not parts:
         raise InvalidAddrError()
 
-    ipfspart = parts[-1]
-    if ipfspart.protocols()[0].code != multiaddr.protocols.P_IPFS:
+    p2ppart = parts[-1]
+    if p2ppart.protocols()[0].code != multiaddr.protocols.P_P2P:
         raise InvalidAddrError()
 
-    # make sure the /ipfs value parses as a peer.ID
-    peer_id_str = ipfspart.value_for_protocol(multiaddr.protocols.P_IPFS)
+    # make sure the /p2p value parses as a peer.ID
+    peer_id_str = p2ppart.value_for_protocol(multiaddr.protocols.P_P2P)
     peer_id = id_b58_decode(peer_id_str)
 
-    # we might have received just an / ipfs part, which means there's no addr.
+    # we might have received just an / p2p part, which means there's no addr.
     if len(parts) > 1:
         addr = multiaddr.util.join(parts[:-1])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pytest-asyncio
 click
 base58
 pymultihash
-py-multiaddr
+multiaddr

--- a/tests/libp2p/test_libp2p.py
+++ b/tests/libp2p/test_libp2p.py
@@ -149,6 +149,6 @@ async def test_host_connect():
     assert len(node_a.get_peerstore().peers()) == 1
 
     assert node_b.get_id() in node_a.get_peerstore().peers()
-    ma_node_b = multiaddr.Multiaddr('/ipfs/%s' % node_b.get_id().pretty())
+    ma_node_b = multiaddr.Multiaddr('/p2p/%s' % node_b.get_id().pretty())
     for addr in node_a.get_peerstore().addrs(node_b.get_id()):
         assert addr.encapsulate(ma_node_b) in node_b.get_addrs()

--- a/tests/peer/test_peerinfo.py
+++ b/tests/peer/test_peerinfo.py
@@ -4,7 +4,7 @@ from peer.peerinfo import info_from_p2p_addr
 
 def test_info_from_p2p_addr():
     # pylint: disable=line-too-long
-    m_addr = multiaddr.Multiaddr('/ip4/127.0.0.1/tcp/8000/ipfs/3YgLAeMKSAPcGqZkAt8mREqhQXmJT8SN8VCMN4T6ih4GNX9wvK8mWJnWZ1qA2mLdCQ')
+    m_addr = multiaddr.Multiaddr('/ip4/127.0.0.1/tcp/8000/p2p/3YgLAeMKSAPcGqZkAt8mREqhQXmJT8SN8VCMN4T6ih4GNX9wvK8mWJnWZ1qA2mLdCQ')
     info = info_from_p2p_addr(m_addr)
     assert info.peer_id.pretty() == '3YgLAeMKSAPcGqZkAt8mREqhQXmJT8SN8VCMN4T6ih4GNX9wvK8mWJnWZ1qA2mLdCQ'
     assert len(info.addrs) == 1

--- a/transport/tcp/tcp.py
+++ b/transport/tcp/tcp.py
@@ -26,7 +26,7 @@ class TCP(ITransport):
             :return: return True if successful
             """
             _multiaddr = multiaddr
-            _multiaddr = _multiaddr.decapsulate('/ipfs')
+            _multiaddr = _multiaddr.decapsulate('/p2p')
 
             coroutine = asyncio.start_server(self.handler,
                                              _multiaddr.value_for_protocol('ip4'),


### PR DESCRIPTION
As in #93, we update to the [new multiaddr dependency](https://pypi.org/project/multiaddr/), but we change usage of `ipfs` in py-libp2p code to `p2p` as per [updates to the multiaddr repo](https://github.com/multiformats/py-multiaddr/pull/27).

#93 can be closed if this PR lands.