### PR TITLE
Fixing linting errors in protocol_muxer and adding to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ python:
   - "3.6"
 
 install:
-  - pip install -r requirements.txt
-  - pip install codecov pytest pytest-cov
+  - pip install --upgrade pip
+  - pip install "pytest>=3.6"
+  - pip install codecov pytest-cov pytest-asyncio pylint
+  - python setup.py develop
 
 script:
   - pytest --cov=./ -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 
 script:
   - pytest --cov=./ -v
-  - pylint --rcfile=.pylintrc encryption host libp2p network peer stream_muxer transport tests
+  - pylint --rcfile=.pylintrc encryption host libp2p network peer protocol_muxer stream_muxer transport tests
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
 
 install:
   - pip install --upgrade pip
+  - pip install -r requirements.txt
   - pip install "pytest>=3.6"
   - pip install codecov pytest-cov pytest-asyncio pylint
-  - python setup.py develop
 
 script:
   - pytest --cov=./ -v

--- a/protocol_muxer/multiselect.py
+++ b/protocol_muxer/multiselect.py
@@ -72,21 +72,22 @@ class Multiselect(IMultiselectMuxer):
         handshake_contents = await communicator.read_stream_until_eof()
 
         # Confirm that the protocols are the same
-        if not self.validate_handshake(handshake_contents):
+        if not validate_handshake(handshake_contents):
             raise MultiselectError("multiselect protocol ID mismatch")
 
         # Handshake succeeded if this point is reached
 
-    def validate_handshake(self, handshake_contents):
-        """
-        Determine if handshake is valid and should be confirmed
-        :param handshake_contents: contents of handshake message
-        :return: true if handshake is complete, false otherwise
-        """
 
-        # TODO: Modify this when format used by go repo for messages
-        # is added
-        return handshake_contents == MULTISELECT_PROTOCOL_ID
+def validate_handshake(handshake_contents):
+    """
+    Determine if handshake is valid and should be confirmed
+    :param handshake_contents: contents of handshake message
+    :return: true if handshake is complete, false otherwise
+    """
+
+    # TODO: Modify this when format used by go repo for messages
+    # is added
+    return handshake_contents == MULTISELECT_PROTOCOL_ID
 
 class MultiselectError(ValueError):
     """Raised when an error occurs in multiselect process"""

--- a/protocol_muxer/multiselect_client.py
+++ b/protocol_muxer/multiselect_client.py
@@ -9,7 +9,7 @@ class MultiselectClient(IMultiselectClient):
     Client for communicating with receiver's multiselect
     module in order to select a protocol id to communicate over
     """
-    
+
     def __init__(self):
         pass
 
@@ -30,21 +30,10 @@ class MultiselectClient(IMultiselectClient):
         handshake_contents = await communicator.read_stream_until_eof()
 
         # Confirm that the protocols are the same
-        if not self.validate_handshake(handshake_contents):
+        if not validate_handshake(handshake_contents):
             raise MultiselectClientError("multiselect protocol ID mismatch")
 
         # Handshake succeeded if this point is reached
-
-    def validate_handshake(self, handshake_contents):
-        """
-        Determine if handshake is valid and should be confirmed
-        :param handshake_contents: contents of handshake message
-        :return: true if handshake is complete, false otherwise
-        """
-
-        # TODO: Modify this when format used by go repo for messages
-        # is added
-        return handshake_contents == MULTISELECT_PROTOCOL_ID
 
     async def select_protocol_or_fail(self, protocol, stream):
         """
@@ -116,6 +105,18 @@ class MultiselectClient(IMultiselectClient):
             raise MultiselectClientError("protocol not supported")
         else:
             raise MultiselectClientError("unrecognized response: " + response)
+
+
+def validate_handshake(handshake_contents):
+    """
+    Determine if handshake is valid and should be confirmed
+    :param handshake_contents: contents of handshake message
+    :return: true if handshake is complete, false otherwise
+    """
+
+    # TODO: Modify this when format used by go repo for messages
+    # is added
+    return handshake_contents == MULTISELECT_PROTOCOL_ID
 
 class MultiselectClientError(ValueError):
     """Raised when an error occurs in protocol selection process"""

--- a/protocol_muxer/multiselect_communicator.py
+++ b/protocol_muxer/multiselect_communicator.py
@@ -6,7 +6,7 @@ class MultiselectCommunicator(IMultiselectCommunicator):
     and multistream module will follow the same multistream protocol,
     which is necessary for them to work
     """
-    
+
     def __init__(self, stream):
         self.stream = stream
 


### PR DESCRIPTION
The old Travis config accidentally excluded `protocol_muxer`. This PR adds it and fixes its `pylint` errors. Note that we'll update our Travis config[ to be more robust](https://github.com/zixuanzh/py-libp2p/blob/597f94ddb2b9aca968ed5421cbdfb6c15c7e2704/.travis.yml#L14) through #105 (removing the `protocol_muxer` exclusion once this PR lands).