### PR TITLE
Fixing setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import setuptools
 
 


### PR DESCRIPTION
Adding this allow users to lunch using ./setup.py install, wich is simpler than python{3} setup.py install.